### PR TITLE
Separate dev dependencies from library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,11 @@ edition = "2018"
 
 [dependencies]
 reqwest = "0.11.3"
-tokio = {version = "1.5.0", features = ["full"]}
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
 scraper = "0.12.0"
+
+
+[dev-dependencies]
+tokio = {version = "1.5.0", features = ["full"]}
 dotenv = "0.15.0"


### PR DESCRIPTION
This should cut down compile times for the library while still giving you what you need to test