### PR TITLE
Note invariants with self-documenting code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ impl Genius {
             .send()
             .await?;
         let res = request.json::<Response>().await?;
-        Ok(res.response.hits.unwrap())
+        Ok(res.response.hits.expect("Genius response did not include \"hits\" field."))
     }
 
     /// Get lyrics with an url of genius song like: <https://genius.com/Sia-chandelier-lyrics>
@@ -147,10 +147,12 @@ impl Genius {
             .await?
             .text()
             .await?;
-        let regex_italic = Regex::new("</*i>").unwrap();
+        let regex_italic = Regex::new("</*i>")
+            .expect("Could not compile regex used to identify italic tags.");
         let html = String::from(regex_italic.replace_all(res, ""));
         let document = Html::parse_document(&html);
-        let lyrics_selector = Selector::parse("div.Lyrics__Container-sc-1ynbvzw-8").unwrap();
+        let lyrics_selector = Selector::parse("div.Lyrics__Container-sc-1ynbvzw-8")
+            .expect("Error parsing for lyrics container elements in Genius page.");
         let mut lyrics = vec![];
         document.select(&lyrics_selector).for_each(|elem| {
             elem.text().for_each(|text| {
@@ -169,7 +171,7 @@ impl Genius {
             .send()
             .await?;
         let res = request.json::<Response>().await?;
-        Ok(res.response.song.unwrap())
+        Ok(res.response.song.expect("Genius response did not include \"song\" field."))
     }
     /// Get deeper information from a album by it's id, `text_format` is the field for the format of text bodies related to the document. Available text formats are `plain` and `html`
     pub async fn get_album(&self, id: u32, text_format: &str) -> Result<Album, reqwest::Error> {
@@ -180,7 +182,7 @@ impl Genius {
             .send()
             .await?;
         let res = request.json::<Response>().await?;
-        Ok(res.response.album.unwrap())
+        Ok(res.response.album.expect("Genius response did not include \"album\" field."))
     }
 }
 


### PR DESCRIPTION
The Genius API this crate wraps sucks. It is poorly documented, and doesn't indicate some of the weird cases that can possibly happen, and what can't happen. It's hard to hit a moving target, and this crate admirably attempts to. The crate also seems to map well to the perceived invariants in Genius API responses, when it comes to the format of said responses.

However, the methods in this crate papers over that complexity in a way that doesn't **directly** map to what the responses actually provide. Particularly, this crate's types liberally use `Option` when a field in a result could simply not be there, but the methods assume those fields will be. The use of `Option` in an intermediary `BlobResponse` is the current work around, but `serde` and Rust provide other ways of dealing with this issue.

The first commit of this draft PR simply documents the invariants this crate relies on by replacing `unwrap` methods with `expect` methods that include messages documenting the invariants relied upon. However, a better approach may be to rethink the `BlobResponse` type and instead use an enum that, in combination with `serde`, could more closely map to the same invariants. The types should map as closely as possible to the results being parsed. 